### PR TITLE
Substitute magic numbers for class constants

### DIFF
--- a/udiscord/bot.py
+++ b/udiscord/bot.py
@@ -61,7 +61,7 @@ class Bot:
     async def send_heartbeat(self) -> None:
         await self.send(
             {
-                "op": 1,
+                "op": self.HEARTBEAT,
                 "d": self.sequence,
             }
         )
@@ -81,7 +81,7 @@ class Bot:
     async def identify(self) -> None:
         await self.send(
             {
-                "op": 2,
+                "op": self.IDENTIFY,
                 "d": {
                     "token": self.token,
                     "intents": self.intents,
@@ -116,7 +116,7 @@ class Bot:
     async def resume(self) -> None:
         await self.send(
             {
-                "op": 6,
+                "op": self.RESUME,
                 "d": {
                     "token": self.token,
                     "session_id": self.session_id,


### PR DESCRIPTION
The use of "magic numbers" is not recommended, and you've already made them a class variable, and so I just substituted the magic numbers for the constants.